### PR TITLE
Add unittest2 as tests_require in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author="Yann Kaiser",
     author_email="kaiser.yann@gmail.com",
     url="https://github.com/epsy/repeated_test",
+    tests_require=['unittest2'],
     install_requires=['six'],
     test_suite="repeated_test.tests",
     keywords=['test', 'testing', 'unittest', 'fixtures'],


### PR DESCRIPTION
This pr adds the ability to run tests using python setup.py tests

see epsy/sigtools/issues/4 and epsy/sigtools/pull/5