### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include .coveragerc
 include .gitignore
 include tox.ini
 include .travis.yml
+include LICENSE.txt


### PR DESCRIPTION
Adds the license file to `MANIFEST.in`.

xref: https://github.com/epsy/repeated_test/pull/3

cc @proinsias