### PR TITLE
Include releases/* tags for deploying new versions

### DIFF
--- a/.github/workflows/deploy-pypi.yaml
+++ b/.github/workflows/deploy-pypi.yaml
@@ -1,10 +1,11 @@
 name: Publish Python package to PyPI
 
 on:
+  push:
+    tags:
+      - releases/*
   release:
     types:
-      - created
-      - edited
       - published
 
 jobs:


### PR DESCRIPTION
Turns out GitHub Actions are not allowed to trigger for Release drafts, so using this instead to get a test run of deployments.